### PR TITLE
Patch for processed 3D data loader

### DIFF
--- a/boom/data/load_processed_3d_data.py
+++ b/boom/data/load_processed_3d_data.py
@@ -30,6 +30,6 @@ def load_3D_data(property, cached_file, split_file=None):
             "u298",
             "zpve",
         ]:
-            return retrieve_qm9_dataset(cache_file_name=cached_file)
+            return retrieve_qm9_dataset(cache_file_name=cached_file, split_file=split_file)
         else:
             ValueError("Other 3D datasets currently not tested")

--- a/boom/data/prepare_3D_mols.py
+++ b/boom/data/prepare_3D_mols.py
@@ -77,7 +77,7 @@ def retrieve_qm9_dataset(cache_file_name, split_file):
     # smiles_data = package_data_loader("qm9_data_with_ood_splits_with_inchi.csv")
 
     with open(split_file, "r") as f:
-        data = f.read().splitlines()
+        smiles_data = f.read().splitlines()
     smiles_list = [x.strip().split(",")[0] for x in smiles_data[1:]]
     smiles_list = [Chem.MolToSmiles(Chem.MolFromSmiles(x)) for x in smiles_list]
     # inchi_list = [Chem.MolToInchi(Chem.MolFromSmiles(x)) for x in smiles_list]

--- a/boom/datasets/CoordDataset.py
+++ b/boom/datasets/CoordDataset.py
@@ -51,12 +51,9 @@ class CoordDataset:
                 split_file = os.path.join(
                     cur_dir, "qm9_data_with_ood_splits_with_inchi.csv"
                 )
-
-        self.data = load_3D_data(self.property, cached_file, split_file)
-
-        self.dataset_type = f"{split.lower()}_{property.lower()}"
-
         data = load_processed_data(property, split_file)
+        self.data = load_3D_data(self.property, cached_file, split_file)
+        self.dataset_type = f"{split.lower()}_{property.lower()}"
 
         assert type(data) == dict
         assert type(self.data) == dict


### PR DESCRIPTION
Fixes the issue with missing split file parameter in `coord_dataset` and `load_processed_3d_data`